### PR TITLE
C2PA-54: Support for C2PA v0.1 table

### DIFF
--- a/fonttools-cli/src/bin/ttf-add-c2pa-table.rs
+++ b/fonttools-cli/src/bin/ttf-add-c2pa-table.rs
@@ -1,0 +1,56 @@
+use clap::{App, Arg};
+use fonttools::{tables::C2PA::C2PA};
+use fonttools_cli::{open_font, save_font};
+use fonttools::tables::C2PA::TAG as c2pa_tag;
+
+fn main() {
+    env_logger::init();
+    let matches = App::new("ttf-add-c2pa-table")
+        .about("Adds a C2PA v0.1 table to a font.")
+        .arg(
+            Arg::with_name("INPUT")
+                .help("Sets the input file to use")
+                .required(false),
+        )
+        .arg(
+            Arg::with_name("OUTPUT")
+                .help("Sets the output file to use")
+                .required(false),
+        )
+        .arg(
+          Arg::with_name("replace")
+            .short("x")
+            .long("replace")
+            .conflicts_with("remove")
+            .help("Even if the font contains a C2PA table, replace with new empty table")
+            .required(false),
+        )
+        .arg(
+          Arg::with_name("remove")
+            .long("remove")
+            .short("r")
+            .conflicts_with("replace")
+            .help("Remove the C2PA table from the font")
+            .required(false),
+        )
+        .get_matches();
+    let mut in_font = open_font(&matches);
+    let has_c2pa = in_font.tables.contains(&c2pa_tag);
+    // if has c2pa and want to remove
+    // else if has c2pa and want to
+    if has_c2pa && !matches.is_present("replace") && !matches.is_present("remove") {
+      log::error!("C2PA table is already present.");
+    }
+    else if !has_c2pa && matches.is_present("remove") {
+      log::error!("C2PA table is not present, nothing to remove");
+    }
+    else if matches.is_present("remove") {
+      in_font.tables.remove(c2pa_tag);
+    }
+    else {
+      let c2pa = C2PA::default();
+      in_font.tables.insert(c2pa);
+    }
+
+    save_font(in_font, &matches);
+}

--- a/fonttools-cli/src/bin/ttf-add-c2pa-table.rs
+++ b/fonttools-cli/src/bin/ttf-add-c2pa-table.rs
@@ -33,6 +33,15 @@ fn main() {
             .help("Remove the C2PA table from the font")
             .required(false),
         )
+        .arg(
+          Arg::with_name("active-manifest-uri")
+            .long("active-manifest-uri")
+            .short("a")
+            .conflicts_with("remove")
+            .takes_value(true)
+            .help("Optional URI to an active manifest")
+            .required(false)
+        )
         .get_matches();
     let mut in_font = open_font(&matches);
     let has_c2pa = in_font.tables.contains(&c2pa_tag);
@@ -48,7 +57,10 @@ fn main() {
       in_font.tables.remove(c2pa_tag);
     }
     else {
-      let c2pa = C2PA::default();
+      let c2pa = C2PA::new(
+        matches.value_of("active-manifest-uri").map(|v| v.to_owned()),
+        None
+      );
       in_font.tables.insert(c2pa);
     }
 

--- a/fonttools-rs/src/table_store.rs
+++ b/fonttools-rs/src/table_store.rs
@@ -73,6 +73,8 @@ pub struct Table {
 pub enum LoadedTable {
     /// Contains an axis variations table.
     avar(Rc<tables::avar::avar>),
+    /// Contains a C2PA manifest store and/or active manifest URI table.
+    C2PA(Rc<tables::C2PA::C2PA>),
     /// Contains a character to glyph index mapping table.
     cmap(Rc<tables::cmap::cmap>),
     /// Contains a control value table.
@@ -617,6 +619,7 @@ table_boilerplate!(tables::GPOS::GPOS, GPOS);
 table_boilerplate!(tables::GSUB::GSUB, GSUB);
 table_boilerplate!(tables::STAT::STAT, STAT);
 table_boilerplate!(tables::avar::avar, avar);
+table_boilerplate!(tables::C2PA::C2PA, C2PA);
 table_boilerplate!(tables::cmap::cmap, cmap);
 table_boilerplate!(tables::cvt::cvt, cvt);
 table_boilerplate!(tables::fpgm::fpgm, fpgm);
@@ -640,6 +643,7 @@ impl Serialize for LoadedTable {
         match self {
             LoadedTable::Unknown(expr) => expr.to_bytes(data),
             LoadedTable::avar(expr) => expr.to_bytes(data),
+            LoadedTable::C2PA(expr) => expr.to_bytes(data),
             LoadedTable::cmap(expr) => expr.to_bytes(data),
             LoadedTable::cvt(expr) => expr.to_bytes(data),
             LoadedTable::fpgm(expr) => expr.to_bytes(data),

--- a/fonttools-rs/src/tables.rs
+++ b/fonttools-rs/src/tables.rs
@@ -1,3 +1,6 @@
+/// The `C2PA` (C2PA manifest store) table
+#[allow(non_snake_case)]
+pub mod C2PA;
 /// The `GDEF` (Glyph definition) table
 #[allow(non_snake_case)]
 pub mod GDEF;

--- a/fonttools-rs/src/tables/C2PA.rs
+++ b/fonttools-rs/src/tables/C2PA.rs
@@ -60,7 +60,7 @@ impl Default for C2PA {
             majorVersion: 0,
             minorVersion: 1,
             activeManifestUri: Default::default(),
-            c2paManifestStore: Default::default()
+            c2paManifestStore: Default::default(),
         }
     }
 }

--- a/fonttools-rs/src/tables/C2PA.rs
+++ b/fonttools-rs/src/tables/C2PA.rs
@@ -32,7 +32,7 @@ tables!(
 /// an embedded manifest store.
 #[derive(Clone, Debug, PartialEq, Eq)]
 #[allow(non_snake_case)]
-pub struct C2PARecord {
+pub struct C2PA {
     /// Major version of the C2PA table record
     pub majorVersion: uint16,
     /// Minor version of the C2PA table record
@@ -43,9 +43,9 @@ pub struct C2PARecord {
     pub c2paManifestStore: Option<String>,
 }
 
-impl C2PARecord {}
+impl C2PA {}
 
-impl Deserialize for C2PARecord {
+impl Deserialize for C2PA {
     fn from_bytes(c: &mut ReaderContext) -> Result<Self, DeserializationError> {
         let mut active_manifest_uri: Option<String> = None;
         let mut c2pa_manifest_store: Option<String> = None;
@@ -89,7 +89,7 @@ impl Deserialize for C2PARecord {
         c.pop();
 
         // Return our record
-        Ok(C2PARecord {
+        Ok(C2PA {
             majorVersion: internal_record.majorVersion,
             minorVersion: internal_record.minorVersion,
             activeManifestUri: active_manifest_uri,
@@ -98,7 +98,7 @@ impl Deserialize for C2PARecord {
     }
 }
 
-impl Serialize for C2PARecord {
+impl Serialize for C2PA {
     fn to_bytes(&self, data: &mut Vec<u8>) -> Result<(), SerializationError> {
         // The main offset to the data includes the major/minor versions,
         // the offset/length of the active manifest uri, and the
@@ -153,7 +153,7 @@ impl Serialize for C2PARecord {
 mod tests {
     #[test]
     fn c2pa_none_uri() {
-        let c2pa = super::C2PARecord {
+        let c2pa = super::C2PA {
             majorVersion: 0,
             minorVersion: 1,
             activeManifestUri: None,
@@ -168,14 +168,14 @@ mod tests {
             0x00, 0x00, 0x00, 0x09, // C2PA manifest store length
             0x74, 0x65, 0x73, 0x74, 0x2D, 0x64, 0x61, 0x74, 0x61, // C2PA manifest store data
         ];
-        let deserialized: super::C2PARecord = otspec::de::from_bytes(&binary_c2pa).unwrap();
+        let deserialized: super::C2PA = otspec::de::from_bytes(&binary_c2pa).unwrap();
         assert_eq!(deserialized, c2pa);
         let serialized = otspec::ser::to_bytes(&deserialized).unwrap();
         assert_eq!(serialized, binary_c2pa);
     }
     #[test]
     fn c2pa_none_manifest_store() {
-        let c2pa = super::C2PARecord {
+        let c2pa = super::C2PA {
             majorVersion: 0,
             minorVersion: 1,
             activeManifestUri: Some("file://a".to_owned()),
@@ -190,14 +190,14 @@ mod tests {
             0x00, 0x00, 0x00, 0x00, // C2PA manifest store length
             0x66, 0x69, 0x6C, 0x65, 0x3A, 0x2F, 0x2F, 0x61, // active manifest uri data
         ];
-        let deserialized: super::C2PARecord = otspec::de::from_bytes(&binary_c2pa).unwrap();
+        let deserialized: super::C2PA = otspec::de::from_bytes(&binary_c2pa).unwrap();
         assert_eq!(deserialized, c2pa);
         let serialized = otspec::ser::to_bytes(&deserialized).unwrap();
         assert_eq!(serialized, binary_c2pa);
     }
     #[test]
     fn c2pa_otspec() {
-        let c2pa = super::C2PARecord {
+        let c2pa = super::C2PA {
             majorVersion: 0,
             minorVersion: 1,
             activeManifestUri: Some("file://a".to_owned()),
@@ -213,7 +213,7 @@ mod tests {
             0x66, 0x69, 0x6C, 0x65, 0x3A, 0x2F, 0x2F, 0x61, // active manifest uri data
             0x74, 0x65, 0x73, 0x74, 0x2D, 0x64, 0x61, 0x74, 0x61, // C2PA manifest store data
         ];
-        let deserialized: super::C2PARecord = otspec::de::from_bytes(&binary_c2pa).unwrap();
+        let deserialized: super::C2PA = otspec::de::from_bytes(&binary_c2pa).unwrap();
         assert_eq!(deserialized, c2pa);
         let serialized = otspec::ser::to_bytes(&deserialized).unwrap();
         assert_eq!(serialized, binary_c2pa);

--- a/fonttools-rs/src/tables/C2PA.rs
+++ b/fonttools-rs/src/tables/C2PA.rs
@@ -1,0 +1,215 @@
+/**
+ * @copyright 2023 Monotype Imaging Inc.
+ *
+ * @file C2PA.rs
+ *
+ * @brief C2PA OpenType extension font table
+ *
+ */
+use otspec::types::*;
+use otspec::{
+    DeserializationError, Deserialize, Deserializer, ReaderContext, SerializationError, Serialize,
+};
+use otspec_macros::tables;
+use std::str;
+
+/// The 'C2PA' OpenType extension tag.
+pub const TAG: Tag = crate::tag!("C2PA");
+
+// Defines the internal C2PA header record
+tables!(
+    C2PARecordInternal {
+        uint16 majorVersion
+        uint16 minorVersion
+        u32 activeManifestUriOffset
+        uint16 activeManifestUriLength
+        u32 c2paManifestStoreOffset
+        u32 c2paManifestStoreLength
+    }
+);
+
+/// A C2PA record, containing information about a current active manifest and/or
+/// an embedded manifest store.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[allow(non_snake_case)]
+pub struct C2PARecord {
+    /// Major version of the C2PA table record
+    pub majorVersion: uint16,
+    /// Minor version of the C2PA table record
+    pub minorVersion: uint16,
+    /// Optional URI to an active manifest
+    pub activeManifestUri: Option<String>,
+    /// Optional embedded manifest store
+    pub c2paManifestStore: Option<String>,
+}
+
+impl C2PARecord {}
+
+impl Deserialize for C2PARecord {
+    fn from_bytes(c: &mut ReaderContext) -> Result<Self, DeserializationError> {
+        // Save the pointer of the current reader context, before we read the
+        // internal record for obtaining the offset from the beginning of the
+        // table to the data as to specification.
+        c.push();
+
+        // Read the components of the C2PA header
+        let internal_record: C2PARecordInternal = c.de()?;
+
+        // Offset to the active manifest URI
+        c.ptr = c.top_of_table() + internal_record.activeManifestUriOffset as usize;
+        // Reading in the active URI as bytes
+        let uri_as_bytes: Vec<u8> =
+            c.de_counted(internal_record.activeManifestUriLength as usize)?;
+        // And converting to a string read as UTF-8 encoding
+        let active_manifest_uri: String = str::from_utf8(&uri_as_bytes)
+            .map_err(|_| {
+                DeserializationError("Failed to read UTF-8 string from bytes".to_string())
+            })?
+            .to_string();
+
+        // Reset the offset to the C2PA manifest store
+        c.ptr = c.top_of_table() + internal_record.c2paManifestStoreOffset as usize;
+        // Read the store as bytes
+        let store_as_bytes: Vec<u8> =
+            c.de_counted(internal_record.c2paManifestStoreLength as usize)?;
+        // And then convert to a string as UTF-8 bytes
+        let c2pa_manifest_store: String = str::from_utf8(&store_as_bytes)
+            .map_err(|_| {
+                DeserializationError("Failed to read UTF-8 string from bytes".to_string())
+            })?
+            .to_string();
+
+        // Restore the state of the reader
+        c.pop();
+
+        // Return our record
+        Ok(C2PARecord {
+            majorVersion: internal_record.majorVersion,
+            minorVersion: internal_record.minorVersion,
+            activeManifestUri: Some(active_manifest_uri),
+            c2paManifestStore: Some(c2pa_manifest_store),
+        })
+    }
+}
+
+impl Serialize for C2PARecord {
+    fn to_bytes(&self, data: &mut Vec<u8>) -> Result<(), SerializationError> {
+        // The main offset to the data includes the major/minor versions,
+        // the offset/length of the active manifest uri, and the
+        // the offset/length of the C2PA manifest store data.
+        let offset: u32 = 18;
+        // Create a data pool for the C2PA data
+        let mut c2pa_data_pool: Vec<u8> = Vec::new();
+
+        // The active manifest is optional, so default to 0 for offset/length
+        let mut active_manifest_offset: u32 = 0_u32;
+        let mut active_manifest_length: u16 = 0_u16;
+        // But if we have a valid active manifest URI, we will use the real
+        // values
+        if let Some(val) = self.activeManifestUri.as_ref() {
+            active_manifest_offset = offset;
+            active_manifest_length = val.len() as u16;
+            // Add the data to the data pool
+            c2pa_data_pool.extend(val.as_bytes());
+        }
+
+        // An embedded manifest store is optional, so default to 0 for
+        // offset/length
+        let mut manifest_store_offset: u32 = 0_u32;
+        let mut manifest_store_length: u32 = 0_u32;
+        // Again, if we do have data for an embedded manifest store, we will use
+        // the real values.
+        if let Some(val) = self.c2paManifestStore.as_ref() {
+            manifest_store_offset = offset + active_manifest_length as u32;
+            manifest_store_length = val.len() as u32;
+            // Adding the data to the data pool to write at the end of the table
+            // entry
+            c2pa_data_pool.extend(val.as_bytes());
+        }
+
+        // At this point, we have everything we need to build the C2PA header
+        // record
+        let c2pa_internal_record = C2PARecordInternal {
+            majorVersion: self.majorVersion,
+            minorVersion: self.minorVersion,
+            activeManifestUriOffset: active_manifest_offset,
+            activeManifestUriLength: active_manifest_length,
+            c2paManifestStoreOffset: manifest_store_offset,
+            c2paManifestStoreLength: manifest_store_length,
+        };
+        // All that is left is to write the header and data to the buffer
+        c2pa_internal_record.to_bytes(data)?;
+        c2pa_data_pool.to_bytes(data)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn c2pa_none_uri() {
+        let c2pa = super::C2PARecord {
+            majorVersion: 0,
+            minorVersion: 1,
+            activeManifestUri: None,
+            c2paManifestStore: Some("test-data".to_owned()),
+        };
+        let binary_c2pa = vec![
+            0x00, 0x00, // Major version
+            0x00, 0x01, // Minor version
+            0x00, 0x00, 0x00, 0x00, // Active manifest URI offset
+            0x00, 0x00, // Active manifest URI length
+            0x00, 0x00, 0x00, 0x10, // C2PA manifest store offset
+            0x00, 0x00, 0x00, 0x09, // C2PA manifest store length
+            0x74, 0x65, 0x73, 0x74, 0x2D, 0x64, 0x61, 0x74, 0x61, // C2PA manifest store data
+        ];
+        let deserialized: super::C2PARecord = otspec::de::from_bytes(&binary_c2pa).unwrap();
+        assert_eq!(deserialized, c2pa);
+        let serialized = otspec::ser::to_bytes(&deserialized).unwrap();
+        assert_eq!(serialized, binary_c2pa);
+    }
+    #[test]
+    fn c2pa_none_manifest_store() {
+        let c2pa = super::C2PARecord {
+            majorVersion: 0,
+            minorVersion: 1,
+            activeManifestUri: Some("file://a".to_owned()),
+            c2paManifestStore: None,
+        };
+        let binary_c2pa = vec![
+            0x00, 0x00, // Major version
+            0x00, 0x01, // Minor version
+            0x00, 0x00, 0x00, 0x12, // Active manifest URI offset
+            0x00, 0x08, // Active manifest URI length
+            0x00, 0x00, 0x00, 0x00, // C2PA manifest store offset
+            0x00, 0x00, 0x00, 0x00, // C2PA manifest store length
+            0x66, 0x69, 0x6C, 0x65, 0x3A, 0x2F, 0x2F, 0x61, // active manifest uri data
+        ];
+        let deserialized: super::C2PARecord = otspec::de::from_bytes(&binary_c2pa).unwrap();
+        assert_eq!(deserialized, c2pa);
+        let serialized = otspec::ser::to_bytes(&deserialized).unwrap();
+        assert_eq!(serialized, binary_c2pa);
+    }
+    #[test]
+    fn c2pa_otspec() {
+        let c2pa = super::C2PARecord {
+            majorVersion: 0,
+            minorVersion: 1,
+            activeManifestUri: Some("file://a".to_owned()),
+            c2paManifestStore: Some("test-data".to_owned()),
+        };
+        let binary_c2pa = vec![
+            0x00, 0x00, // Major version
+            0x00, 0x01, // Minor version
+            0x00, 0x00, 0x00, 0x12, // Active manifest URI offset
+            0x00, 0x08, // Active manifest URI length
+            0x00, 0x00, 0x00, 0x1A, // C2PA manifest store offset
+            0x00, 0x00, 0x00, 0x09, // C2PA manifest store length
+            0x66, 0x69, 0x6C, 0x65, 0x3A, 0x2F, 0x2F, 0x61, // active manifest uri data
+            0x74, 0x65, 0x73, 0x74, 0x2D, 0x64, 0x61, 0x74, 0x61, // C2PA manifest store data
+        ];
+        let deserialized: super::C2PARecord = otspec::de::from_bytes(&binary_c2pa).unwrap();
+        assert_eq!(deserialized, c2pa);
+        let serialized = otspec::ser::to_bytes(&deserialized).unwrap();
+        assert_eq!(serialized, binary_c2pa);
+    }
+}

--- a/fonttools-rs/src/tables/C2PA.rs
+++ b/fonttools-rs/src/tables/C2PA.rs
@@ -64,11 +64,13 @@ impl Deserialize for C2PA {
             let uri_as_bytes: Vec<u8> =
                 c.de_counted(internal_record.activeManifestUriLength as usize)?;
             // And converting to a string read as UTF-8 encoding
-            active_manifest_uri = Some(str::from_utf8(&uri_as_bytes)
-                .map_err(|_| {
-                    DeserializationError("Failed to read UTF-8 string from bytes".to_string())
-                })?
-                .to_string());
+            active_manifest_uri = Some(
+                str::from_utf8(&uri_as_bytes)
+                    .map_err(|_| {
+                        DeserializationError("Failed to read UTF-8 string from bytes".to_string())
+                    })?
+                    .to_string(),
+            );
         }
 
         if internal_record.c2paManifestStoreOffset > 0 {
@@ -78,11 +80,13 @@ impl Deserialize for C2PA {
             let store_as_bytes: Vec<u8> =
                 c.de_counted(internal_record.c2paManifestStoreLength as usize)?;
             // And then convert to a string as UTF-8 bytes
-            c2pa_manifest_store = Some(str::from_utf8(&store_as_bytes)
-                .map_err(|_| {
-                    DeserializationError("Failed to read UTF-8 string from bytes".to_string())
-                })?
-                .to_string());
+            c2pa_manifest_store = Some(
+                str::from_utf8(&store_as_bytes)
+                    .map_err(|_| {
+                        DeserializationError("Failed to read UTF-8 string from bytes".to_string())
+                    })?
+                    .to_string(),
+            );
         }
 
         // Restore the state of the reader
@@ -151,6 +155,7 @@ impl Serialize for C2PA {
 
 #[cfg(test)]
 mod tests {
+    /// Verifies the behavior when the activeManifestUri is None
     #[test]
     fn c2pa_none_uri() {
         let c2pa = super::C2PA {
@@ -173,6 +178,8 @@ mod tests {
         let serialized = otspec::ser::to_bytes(&deserialized).unwrap();
         assert_eq!(serialized, binary_c2pa);
     }
+
+    /// Verifies the behavior when the c2paManifestStore is None
     #[test]
     fn c2pa_none_manifest_store() {
         let c2pa = super::C2PA {
@@ -195,6 +202,9 @@ mod tests {
         let serialized = otspec::ser::to_bytes(&deserialized).unwrap();
         assert_eq!(serialized, binary_c2pa);
     }
+
+    /// Verifies the behavior when there is both an active manifest URI and a
+    /// C2PA manifest store in the font.
     #[test]
     fn c2pa_otspec() {
         let c2pa = super::C2PA {

--- a/fonttools-rs/src/tables/C2PA.rs
+++ b/fonttools-rs/src/tables/C2PA.rs
@@ -23,8 +23,8 @@ tables!(
         uint16 minorVersion
         u32 activeManifestUriOffset
         uint16 activeManifestUriLength
-        u32 c2paManifestStoreOffset
-        u32 c2paManifestStoreLength
+        u32 manifestStoreOffset
+        u32 manifestStoreLength
     }
 );
 
@@ -40,17 +40,23 @@ pub struct C2PA {
     /// Optional URI to an active manifest
     pub activeManifestUri: Option<String>,
     /// Optional embedded manifest store
-    pub c2paManifestStore: Option<String>,
+    manifestStore: Option<Box<[u8]>>,
 }
 
 impl C2PA {
     /// Creates a new C2PA record with the current default version information.
-    pub fn new(active_manifest_uri: Option<String>, c2pa_manifest_store: Option<String>) -> Self {
+    pub fn new(active_manifest_uri: Option<String>, manifest_store: Option<Vec<u8>>) -> Self {
+        let boxed_data = manifest_store.map(|d| d.into_boxed_slice());
         Self {
             activeManifestUri: active_manifest_uri,
-            c2paManifestStore: c2pa_manifest_store,
+            manifestStore: boxed_data,
             ..C2PA::default()
         }
+    }
+
+    /// Get the manifest store data if available
+    pub fn get_manifest_store(&self) -> Option<&[u8]> {
+        self.manifestStore.as_deref()
     }
 }
 
@@ -60,7 +66,7 @@ impl Default for C2PA {
             majorVersion: 0,
             minorVersion: 1,
             activeManifestUri: Default::default(),
-            c2paManifestStore: Default::default(),
+            manifestStore: Default::default(),
         }
     }
 }
@@ -68,7 +74,7 @@ impl Default for C2PA {
 impl Deserialize for C2PA {
     fn from_bytes(c: &mut ReaderContext) -> Result<Self, DeserializationError> {
         let mut active_manifest_uri: Option<String> = None;
-        let mut c2pa_manifest_store: Option<String> = None;
+        let mut manifest_store: Option<Box<[u8]>> = None;
         // Save the pointer of the current reader context, before we read the
         // internal record for obtaining the offset from the beginning of the
         // table to the data as to specification.
@@ -93,20 +99,14 @@ impl Deserialize for C2PA {
             );
         }
 
-        if internal_record.c2paManifestStoreOffset > 0 {
+        if internal_record.manifestStoreOffset > 0 {
             // Reset the offset to the C2PA manifest store
-            c.ptr = c.top_of_table() + internal_record.c2paManifestStoreOffset as usize;
+            c.ptr = c.top_of_table() + internal_record.manifestStoreOffset as usize;
             // Read the store as bytes
-            let store_as_bytes: Vec<u8> =
-                c.de_counted(internal_record.c2paManifestStoreLength as usize)?;
+            let store_as_bytes: Option<Vec<u8>> =
+                Some(c.de_counted(internal_record.manifestStoreLength as usize)?);
             // And then convert to a string as UTF-8 bytes
-            c2pa_manifest_store = Some(
-                str::from_utf8(&store_as_bytes)
-                    .map_err(|_| {
-                        DeserializationError("Failed to read UTF-8 string from bytes".to_string())
-                    })?
-                    .to_string(),
-            );
+            manifest_store = store_as_bytes.map(|d| d.into_boxed_slice());
         }
 
         // Restore the state of the reader
@@ -117,7 +117,7 @@ impl Deserialize for C2PA {
             majorVersion: internal_record.majorVersion,
             minorVersion: internal_record.minorVersion,
             activeManifestUri: active_manifest_uri,
-            c2paManifestStore: c2pa_manifest_store,
+            manifestStore: manifest_store,
         })
     }
 }
@@ -149,12 +149,12 @@ impl Serialize for C2PA {
         let mut manifest_store_length: u32 = 0_u32;
         // Again, if we do have data for an embedded manifest store, we will use
         // the real values.
-        if let Some(val) = self.c2paManifestStore.as_ref() {
+        if let Some(val) = self.manifestStore.as_ref() {
             manifest_store_offset = offset + active_manifest_length as u32;
             manifest_store_length = val.len() as u32;
             // Adding the data to the data pool to write at the end of the table
             // entry
-            c2pa_data_pool.extend(val.as_bytes());
+            c2pa_data_pool.extend(val.iter());
         }
 
         // At this point, we have everything we need to build the C2PA header
@@ -164,8 +164,8 @@ impl Serialize for C2PA {
             minorVersion: self.minorVersion,
             activeManifestUriOffset: active_manifest_offset,
             activeManifestUriLength: active_manifest_length,
-            c2paManifestStoreOffset: manifest_store_offset,
-            c2paManifestStoreLength: manifest_store_length,
+            manifestStoreOffset: manifest_store_offset,
+            manifestStoreLength: manifest_store_length,
         };
         // All that is left is to write the header and data to the buffer
         c2pa_internal_record.to_bytes(data)?;
@@ -182,7 +182,7 @@ mod tests {
             majorVersion: 0,
             minorVersion: 1,
             activeManifestUri: None,
-            c2paManifestStore: Some("test-data".to_owned()),
+            manifestStore: Some(vec![0x74, 0x65, 0x73, 0x74, 0x2D, 0x64, 0x61, 0x74, 0x61].into()),
         };
         let binary_c2pa = vec![
             0x00, 0x00, // Major version
@@ -199,14 +199,14 @@ mod tests {
         assert_eq!(serialized, binary_c2pa);
     }
 
-    /// Verifies the behavior when the c2paManifestStore is None
+    /// Verifies the behavior when the manifestStore is None
     #[test]
     fn c2pa_none_manifest_store() {
         let c2pa = super::C2PA {
             majorVersion: 0,
             minorVersion: 1,
             activeManifestUri: Some("file://a".to_owned()),
-            c2paManifestStore: None,
+            manifestStore: None,
         };
         let binary_c2pa = vec![
             0x00, 0x00, // Major version
@@ -231,7 +231,7 @@ mod tests {
             majorVersion: 0,
             minorVersion: 1,
             activeManifestUri: Some("file://a".to_owned()),
-            c2paManifestStore: Some("test-data".to_owned()),
+            manifestStore: Some(vec![0x74, 0x65, 0x73, 0x74, 0x2D, 0x64, 0x61, 0x74, 0x61].into()),
         };
         let binary_c2pa = vec![
             0x00, 0x00, // Major version

--- a/fonttools-rs/src/tables/C2PA.rs
+++ b/fonttools-rs/src/tables/C2PA.rs
@@ -43,7 +43,27 @@ pub struct C2PA {
     pub c2paManifestStore: Option<String>,
 }
 
-impl C2PA {}
+impl C2PA {
+    /// Creates a new C2PA record with the current default version information.
+    pub fn new(active_manifest_uri: Option<String>, c2pa_manifest_store: Option<String>) -> Self {
+        Self {
+            activeManifestUri: active_manifest_uri,
+            c2paManifestStore: c2pa_manifest_store,
+            ..C2PA::default()
+        }
+    }
+}
+
+impl Default for C2PA {
+    fn default() -> Self {
+        Self {
+            majorVersion: 0,
+            minorVersion: 1,
+            activeManifestUri: Default::default(),
+            c2paManifestStore: Default::default()
+        }
+    }
+}
 
 impl Deserialize for C2PA {
     fn from_bytes(c: &mut ReaderContext) -> Result<Self, DeserializationError> {


### PR DESCRIPTION
# JIRA Issue

- C2PA-54

# Checklist
<!--  Replace the ' ' with an 'x' for each that applies:  -->
- [x] **PR labeled** appropriately
- [ ] **Documentation** updated:
  - [ ] Developer documentation (ReadMe files)
  - [ ] Product documentation (Release notes, PDK Guide, Functional Spec, API documents, ...)
- [ ] **Test case(s)** added
  - [ ] Unit Tests

# Notes for Reviewers
<!--  Information to assist code reviewers:                    -->
<!--    Dependencies or co-reqs (other branches, other repos)  -->
<!--    Limitations and/or breakage.                           -->

Adds support for the C2PA v0.1 table to fonts. Should be able to read, write, remove table from a font file.


# Verification Instructions
<!-- Instructions for checking or testing this change. -->

Step into the `rust-font-tools/fonttools-cli` folder and run:

```shell
> cargo run --bin ttf-add-c2pa-table -- --help
ttf-add-c2pa-table 
Adds a C2PA v0.1 table to a font.

USAGE:
    ttf-add-c2pa-table.exe [FLAGS] [ARGS]

FLAGS:
    -h, --help       Prints help information
    -r, --remove     Remove the C2PA table from the font
    -x, --replace    Even if the font contains a C2PA table, replace with new empty table
    -V, --version    Prints version information

ARGS:
    <INPUT>     Sets the input file to use
    <OUTPUT>    Sets the output file to use

# Try out some of the scenarios, for example one may add a new C2PA table by running:
> cargo run --bin ttf-add-c2pa-table -- C:\Path\To\Input-Font.otf  C:\Path\To\Output-Font.otf

# Or one may replace a C2PA table by running:
> cargo run --bin ttf-add-c2pa-table -- --replace C:\Path\To\Input-Font.otf  C:\Path\To\Output-Font.otf

# And finally the C2PA table could be removed from the font
> cargo run --bin ttf-add-c2pa-table -- --remove C:\Path\To\Input-Font.otf  C:\Path\To\Output-Font.otf
```

The unit tests may be ran to verify as well:

```shell
> cd rust-font-tools/fonttools-rs
rust-font-tools/fonttools-rs> cargo test
```

> Actively maintained by the @Monotype/driverpdldev team.
