### PR TITLE
C2PA-55: Add the C2PA table to the `deserialize_table` call.

### DIFF
--- a/fonttools-rs/src/table_store.rs
+++ b/fonttools-rs/src/table_store.rs
@@ -328,6 +328,7 @@ impl TableSet {
     fn deserialize_table(&self, tag: Tag, data: Rc<[u8]>) -> Result<Table, DeserializationError> {
         let typed_data: LoadedTable = match tag.as_bytes() {
             b"avar" => otspec::de::from_bytes::<tables::avar::avar>(&data)?.into(),
+            b"C2PA" => otspec::de::from_bytes::<tables::C2PA::C2PA>(&data)?.into(),
             b"cmap" => otspec::de::from_bytes::<tables::cmap::cmap>(&data)?.into(),
             b"cvt " => otspec::de::from_bytes::<tables::cvt::cvt>(&data)?.into(),
             b"fpgm" => otspec::de::from_bytes::<tables::fpgm::fpgm>(&data)?.into(),


### PR DESCRIPTION
<!--  Title should use the format: "JIRA-123: Summary of change"   -->
<!--     Branch names for Stories: "feature/JIRA-123/featureName"  -->
<!--        Branch names for Bugs: "fix/JIRA-123/bugFixName"       -->
# JIRA Issue

- https://monotype.atlassian.net/browse/C2PA-55

# Checklist
<!--  Replace the ' ' with an 'x' for each that applies:  -->
- [x] **PR labeled** appropriately
- [ ] **Documentation** updated:
  - [ ] Developer documentation (ReadMe files)
  - [ ] Product documentation (Release notes, PDK Guide, Functional Spec, API documents, ...)
- [ ] **Test case(s)** added
  - [ ] Unit Tests

# Notes for Reviewers

Missed a spot earlier for deserializing the `C2PA` table from the font file.

<!--  Information to assist code reviewers:                    -->
<!--    Dependencies or co-reqs (other branches, other repos)  -->
<!--    Limitations and/or breakage.                           -->

# Verification Instructions

I'm not really sure how to test it out, I found this bug while trying to use it in my changes for using the table in a different project.


> Actively maintained by the @Monotype/driverpdldev team.
